### PR TITLE
feat: auto-generate release notes + bump softprops/action-gh-release to v3

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,5 +1,10 @@
 # Copilot Instructions
 
+<!-- ── Synced section ─────────────────────────────────────────────────────
+     Everything above the "Project-Specific Overrides" heading is kept
+     identical across all f2calv repositories. Edit once, sync everywhere.
+     ──────────────────────────────────────────────────────────────────── -->
+
 ## GitHub Actions
 
 ### General
@@ -102,8 +107,16 @@ Use these consistent heading patterns before Mermaid diagrams:
 
 ## Copilot Workflow
 
+- **Test execution**: Never run tests automatically — they may be integration tests requiring extra setup. Always prompt (ideally with a visual yes/no button) before running any tests.
 - **Preserve git history during renames/moves**: When renaming or relocating files, first perform the rename/move (preferably via `git mv`), then make content edits to the file in its new location/name. This two-step approach preserves git history across the rename. Do not delete-and-recreate files when a rename or move is the intent.
 
 ## Misc
 
 - When detecting new conventions or patterns in the codebase, add them to this document and apply them retroactively where applicable.
+- When multiple `copilot-instructions.md` files are available in the workspace, keep them in sync based on the common guidelines in the synced section.
+
+---
+
+## Project-Specific Overrides
+
+<!-- This section is excluded from cross-repository sync. Place any repo-specific rules below. -->

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -59,8 +59,46 @@
 ### README Consistency
 
 - Every project's `README.md` must stay in sync with its implementation. During any refactoring — and **always** before creating a new PR — scan the `README.md` for inconsistencies: outdated input/output names, missing or removed configuration options, or inaccurate examples. Update the README as part of the same change, not as a follow-up.
-- **Mermaid diagrams**: Use Mermaid diagrams in `README.md` files to illustrate GitHub Actions workflow chains. These diagrams make complex relationships immediately visible and must be kept in sync with the code they describe.
 - **Markdown tables**: Table separator rows must use spaces around pipes to match the spaced style used in header and data rows (e.g. `| --- | --- |` not `|---|---|`). This prevents MD060 (table-column-style) warnings.
+
+### Mermaid Diagrams
+
+Use Mermaid diagrams in `README.md` files to visualize complex relationships and flows. Choose the appropriate diagram type:
+
+#### Diagram Type Selection
+
+- **`flowchart`**: Sequential processes, data flow, event flow, service orchestration, CI/CD pipelines
+  - Direction: Use `TD` (top-down) for vertical flows; `LR` (left-right) for wide workflows
+  - Example: GitHub Actions workflow chains, composite action steps
+
+- **`graph`**: Relationships, dependencies, hierarchies (non-sequential)
+  - Direction: Use `TD` for dependency trees; `LR` for peer relationships
+  - Example: Action dependencies, workflow call chains
+
+#### Standard Headings
+
+Use these consistent heading patterns before Mermaid diagrams:
+
+| Heading | Use For |
+| --- | --- |
+| `## Deployment Flow` | CI/CD pipelines, GitHub Actions workflows, action call chains |
+| `## Dependency Graph` | Action dependencies, workflow relationships |
+
+#### Styling Guidelines
+
+- **Subgraphs**: Group related steps or jobs
+- **Custom styling**: Define `classDef` for highlighting owned vs. third-party actions
+- **Node shapes**:
+  - `[ ]` rectangle (default) - actions, jobs
+  - `([ ])` stadium - workflows
+  - `{ }` diamond - decision points
+
+#### Synchronization
+
+- Mermaid diagrams must stay in sync with action/workflow changes
+- When renaming inputs/outputs, update corresponding diagram nodes
+- When adding/removing action dependencies, update dependency graphs
+- Review all `README.md` diagrams before creating PRs
 
 ## Copilot Workflow
 

--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -4,8 +4,9 @@ branches:
     regex: ^main$
     label: ''
   feature:
-    regex: ^features?[/-]
-    label: useBranchName
+    mode: ContinuousDelivery
+    regex: ^(features?|f2calv|copilot)[/-](?<BranchName>.+)
+    label: '{BranchName}'
 ignore:
   sha: []
 merge-message-formats: {}

--- a/README.md
+++ b/README.md
@@ -12,7 +12,6 @@ jobs:
       contents: write
     outputs:
       version: ${{ steps.release.outputs.version }}
-      fullSemVer: ${{ steps.release.outputs.fullSemVer }}
       major: ${{ steps.release.outputs.major }}
       minor: ${{ steps.release.outputs.minor }}
       patch: ${{ steps.release.outputs.patch }}
@@ -46,9 +45,7 @@ jobs:
 
 | Output | Description |
 | ------ | ----------- |
-| `version` | The calculated semantic version, e.g. `1.2.301`. |
-| `semVer` | **Deprecated** — use `version` instead. |
-| `fullSemVer` | The full semantic version including pre-release info, e.g. `1.2.301-feature-my-feature.12`. |
+| `version` | The calculated semantic version, e.g. `1.2.301` or `1.2.301-feature-my-feature.12+56`. |
 | `major` | The major version component, e.g. `1`. |
 | `minor` | The minor version component, e.g. `2`. |
 | `patch` | The patch version component, e.g. `301`. |

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ jobs:
 | `gv-config` | No | `GitVersion.yml` | Path to the GitVersion configuration file. |
 | `gv-source` | No | `actions` | GitVersion installation source: `actions`, `dotnet`, or `container`. |
 | `dotnet-version` | No | `10.0.x` | .NET SDK version to install when `gv-source` is `dotnet`. |
+| `generate-release-notes` | No | `true` | Auto-generate release notes from merged PRs since the last release. |
 
 ## Outputs
 

--- a/action.yml
+++ b/action.yml
@@ -38,6 +38,11 @@ inputs:
     description: .NET SDK version to install when gv-source is 'dotnet'.
     type: string
     default: 10.0.x
+  generate-release-notes:
+    description: Auto-generate release notes from merged PRs since the last release.
+    required: false
+    type: boolean
+    default: true
 
 outputs:
   version:
@@ -154,7 +159,7 @@ runs:
 
     # Create a GitHub Release for the computed version.
     - name: create release
-      uses: softprops/action-gh-release@v2
+      uses: softprops/action-gh-release@v3
       if: |
         steps.check-release-exists.outputs.ReleaseExists == 'false'
           && (github.ref == format('refs/heads/{0}', github.event.repository.default_branch))
@@ -162,6 +167,7 @@ runs:
       with:
         tag_name: ${{ inputs.tag-prefix }}${{ env.SEMVER }}
         name: ${{ env.FULLSEMVER }}
+        generate_release_notes: ${{ inputs.generate-release-notes }}
 
     # Create or move the rolling major and major.minor version tags to this commit.
     - name: git apply/move major tag


### PR DESCRIPTION
## Summary

Adds auto-generated release notes to GitHub releases and upgrades the release action to v3.

## Changes

### New input
- `generate-release-notes` (default: `true`) — passes `generate_release_notes` to `softprops/action-gh-release`, populating release descriptions with merged PR titles since the last release.

### Action upgrades
- `softprops/action-gh-release` upgraded from `@v2` to `@v3` (Node 20 → Node 24 runtime).

### Documentation
- README inputs table updated with the new `generate-release-notes` input.
- Mermaid diagrams and copilot instructions updated.
- Versioning fix.